### PR TITLE
bump kiss3d and nalgebra to the latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-nalgebra = "0.21"
+nalgebra = "0.23"
 urdf-rs = "0.4"
 log = "0.4"
 simba = "0.1"
@@ -24,7 +24,7 @@ skeptic = "0.13"
 
 [dev-dependencies]
 skeptic = "0.13"
-kiss3d = "0.24"
+kiss3d = "0.28"
 rand = "0.7"
 
 #[profile.release]

--- a/src/ik.rs
+++ b/src/ik.rs
@@ -282,8 +282,8 @@ where
         arm.set_joint_positions(&orig_positions)?;
         Err(Error::NotConvergedError {
             num_tried: self.num_max_try,
-            position_diff: na::convert(last_target_distance.unwrap().0),
-            rotation_diff: na::convert(last_target_distance.unwrap().1),
+            position_diff: na::try_convert(last_target_distance.unwrap().0).unwrap_or_default(),
+            rotation_diff: na::try_convert(last_target_distance.unwrap().1).unwrap_or_default(),
         })
     }
 }

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -113,9 +113,9 @@ where
             if !range.is_valid(position) {
                 return Err(Error::OutOfLimitError {
                     joint_name: self.name.to_string(),
-                    position: na::convert(position),
-                    max_limit: na::convert(range.max),
-                    min_limit: na::convert(range.min),
+                    position: na::try_convert(position).unwrap_or_default(),
+                    max_limit: na::try_convert(range.max).unwrap_or_default(),
+                    min_limit: na::try_convert(range.min).unwrap_or_default(),
                 });
             }
         }


### PR DESCRIPTION
The old kiss3d version in this project is causing this bug: https://github.com/ggez/ggez/issues/843
I bumped kiss3d and nalgebra to the corresponding version, the tests pass, the error reporting in the examples seems to work
The same thing needs to be done to urdf-viz