### PR TITLE
Remove `extern crate`

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -27,7 +27,6 @@ use std::ops::Deref;
 /// # Examples
 ///
 /// ```
-/// #[macro_use]
 /// use k::*;
 /// use k::prelude::*;
 ///

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -53,8 +53,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate nalgebra as na;
-    /// extern crate k;
+    /// use nalgebra as na;
     ///
     /// // create fixed joint
     /// let fixed = k::Joint::<f32>::new("f0", k::JointType::Fixed);
@@ -84,8 +83,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate nalgebra as na;
-    /// extern crate k;
+    /// use nalgebra as na;
     ///
     /// // Create fixed joint
     /// let mut fixed = k::Joint::<f32>::new("f0", k::JointType::Fixed);
@@ -132,8 +130,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate nalgebra as na;
-    /// extern crate k;
+    /// use nalgebra as na;
     ///
     /// // Create rotational joint with Y-axis
     /// let mut rot = k::Joint::<f64>::new("r0", k::JointType::Rotational { axis: na::Vector3::y_axis() });
@@ -211,8 +208,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate nalgebra as na;
-    /// extern crate k;
+    /// use nalgebra as na;
     ///
     /// // Create linear joint with X-axis
     /// let mut lin = k::Joint::<f64>::new("l0", k::JointType::Linear { axis: na::Vector3::x_axis() });

--- a/src/node.rs
+++ b/src/node.rs
@@ -577,7 +577,7 @@ where
 /// set parents easily
 ///
 /// ```
-/// #[macro_use] extern crate k;
+/// use k::connect;
 /// # fn main() {
 /// let l0 = k::NodeBuilder::<f64>::new().into_node();
 /// let l1 = k::NodeBuilder::new().into_node();
@@ -601,6 +601,6 @@ macro_rules! connect {
     };
     ($x:expr => $y:expr => $($rest:tt)+) => {
         $y.set_parent(&$x);
-        connect!($y => $($rest)*);
+        $crate::connect!($y => $($rest)*);
     };
 }

--- a/src/urdf.rs
+++ b/src/urdf.rs
@@ -346,9 +346,6 @@ where
 /// # Examples
 ///
 /// ```
-/// extern crate urdf_rs;
-/// extern crate k;
-///
 /// let urdf_robot = urdf_rs::read_file("urdf/sample.urdf").unwrap();
 /// let map = k::urdf::link_to_joint_map(&urdf_robot);
 /// assert_eq!(map.get("root_body").unwrap(), k::urdf::ROOT_JOINT_NAME);

--- a/tests/test_ik.rs
+++ b/tests/test_ik.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate k;
-extern crate nalgebra as na;
+use k::connect;
+use nalgebra as na;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
In the 2018 edition, this is not needed in most cases.