### PR TITLE
Use doc-comment instead of skeptic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/openrr/k"
 documentation = "http://docs.rs/k"
 readme = "README.md"
 edition = "2018"
-build = "build.rs"
 
 [features]
 default = []
@@ -25,11 +24,8 @@ thiserror = "1.0"
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 
-[build-dependencies]
-skeptic = "0.13"
-
 [dev-dependencies]
-skeptic = "0.13"
+doc-comment = "0.3"
 kiss3d = "0.29"
 rand = "0.8"
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@
 //!
 //! See `Chain` as the top level interface.
 //!
+
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
+
 mod chain;
 mod errors;
 mod funcs;


### PR DESCRIPTION
Seems skeptic is used only for testing, but since it is a build-dependency, it is always compiled even in normal builds.
Hopefully, this patch may help reduce compile time.

Refs: 
- https://github.com/GuillaumeGomez/doc-comment
- https://github.com/budziq/rust-skeptic#simpler-solution