### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ serde-serialize = ["nalgebra/serde-serialize", "serde"]
 # Note: nalgebra, simba, urdf-rs, and serde are public dependencies.
 [dependencies]
 log = "0.4"
-nalgebra = "0.24"
-simba = "0.3"
+nalgebra = "0.25"
+simba = "0.4"
 thiserror = "1.0"
 urdf-rs = "0.6"
 
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"
-kiss3d = "0.29"
+kiss3d = "0.30"
 rand = "0.8"
 
 #[profile.release]


### PR DESCRIPTION
dependencies:
- nalgebra 0.24 -> 0.25
- simba 0.3 -> 0.4

dev-dependencies:
- kiss3d 0.29 -> 0.30

Note that this is a breaking change because update public dependencies.