### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ keywords = ["kinematics", "robotics", "ik"]
 categories = ["algorithms"]
 repository = "https://github.com/openrr/k"
 documentation = "http://docs.rs/k"
-readme = "README.md"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field if readme is in the default location (e.g., `readme = "README.md"`).

