### PR TITLE
Re-export nalgebra as na

### DIFF
--- a/benches/fk.rs
+++ b/benches/fk.rs
@@ -2,8 +2,8 @@
 #![feature(test)]
 
 extern crate test;
+use k::na;
 use na::RealField;
-use nalgebra as na;
 use std::f64::consts::PI;
 
 /*

--- a/examples/interactive_ik.rs
+++ b/examples/interactive_ik.rs
@@ -13,10 +13,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-use nalgebra as na;
 
 use k::prelude::*;
-use k::{connect, JacobianIkSolver, JointType, NodeBuilder};
+use k::{connect, na, JacobianIkSolver, JointType, NodeBuilder};
 use kiss3d::camera::ArcBall;
 use kiss3d::event::{Action, Key, WindowEvent};
 use kiss3d::light::Light;

--- a/examples/interactive_ik_scara.rs
+++ b/examples/interactive_ik_scara.rs
@@ -13,10 +13,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-use nalgebra as na;
 
 use k::prelude::*;
-use k::{connect, JacobianIkSolver, JointType, NodeBuilder};
+use k::{connect, na, JacobianIkSolver, JointType, NodeBuilder};
 use kiss3d::camera::ArcBall;
 use kiss3d::event::{Action, Key, WindowEvent};
 use kiss3d::light::Light;

--- a/examples/print.rs
+++ b/examples/print.rs
@@ -1,4 +1,4 @@
-use nalgebra as na;
+use k::na;
 
 fn main() {
     let l0 = k::Node::new(

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -17,7 +17,6 @@ use super::errors::*;
 use super::joint::*;
 use super::node::*;
 use na::{Isometry3, RealField};
-use nalgebra as na;
 use simba::scalar::SubsetOf;
 use std::fmt::{self, Display};
 use std::ops::Deref;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-use nalgebra as na;
 use thiserror::Error;
 
 /// The reason of joint error

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -1,7 +1,6 @@
 use super::chain::*;
 use super::joint::*;
 use na::{DMatrix, RealField, Vector3};
-use nalgebra as na;
 use simba::scalar::SubsetOf;
 
 /// Calculate Jacobian of the serial chain (manipulator).

--- a/src/ik.rs
+++ b/src/ik.rs
@@ -14,7 +14,6 @@
   limitations under the License.
 */
 use na::{DVector, Isometry3, RealField, Vector3, Vector6};
-use nalgebra as na;
 #[cfg(feature = "serde-serialize")]
 use serde::{Deserialize, Serialize};
 use simba::scalar::SubsetOf;

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -18,7 +18,6 @@ use super::range::*;
 use super::velocity::*;
 use crate::errors::*;
 use na::{Isometry3, RealField, Translation3, UnitQuaternion};
-use nalgebra as na;
 use simba::scalar::SubsetOf;
 use std::cell::RefCell;
 use std::fmt::{self, Display};
@@ -53,7 +52,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// use k::na;
     ///
     /// // create fixed joint
     /// let fixed = k::Joint::<f32>::new("f0", k::JointType::Fixed);
@@ -83,7 +82,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// use k::na;
     ///
     /// // Create fixed joint
     /// let mut fixed = k::Joint::<f32>::new("f0", k::JointType::Fixed);
@@ -130,7 +129,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// use k::na;
     ///
     /// // Create rotational joint with Y-axis
     /// let mut rot = k::Joint::<f64>::new("r0", k::JointType::Rotational { axis: na::Vector3::y_axis() });
@@ -208,7 +207,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// use k::na;
     ///
     /// // Create linear joint with X-axis
     /// let mut lin = k::Joint::<f64>::new("l0", k::JointType::Linear { axis: na::Vector3::x_axis() });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ mod chain;
 mod errors;
 mod funcs;
 mod ik;
-use nalgebra as na;
 pub mod iterator;
 pub mod joint;
 pub mod link;
@@ -52,6 +51,6 @@ pub use self::node::{Node, NodeBuilder};
 // (na::Real used to be the name, so we used to re-export k::Real)
 pub use na::{Isometry3, RealField as Real, RealField, Translation3, UnitQuaternion, Vector3};
 // export everything
-pub use nalgebra;
+pub extern crate nalgebra as na;
 pub use simba;
 pub use simba::scalar::{SubsetOf, SupersetOf};

--- a/src/link.rs
+++ b/src/link.rs
@@ -18,7 +18,6 @@
 //! `link` module is optional for `k`.
 //!
 use na::{Isometry3, Matrix3, RealField, Vector3};
-use nalgebra as na;
 
 #[derive(Debug, Clone)]
 pub enum Geometry<T: RealField> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,7 +15,6 @@
 */
 //! graph structure for kinematic chain
 use na::{Isometry3, RealField, Translation3, UnitQuaternion};
-use nalgebra as na;
 use simba::scalar::SubsetOf;
 use std::fmt::{self, Display};
 use std::ops::Deref;

--- a/src/urdf.rs
+++ b/src/urdf.rs
@@ -22,7 +22,6 @@ use super::link::*;
 use super::node::*;
 use log::*;
 use na::{Isometry3, Matrix3, RealField};
-use nalgebra as na;
 use simba::scalar::SubsetOf;
 use std::collections::HashMap;
 use std::path::Path;

--- a/tests/test_ik.rs
+++ b/tests/test_ik.rs
@@ -1,5 +1,4 @@
-use k::connect;
-use nalgebra as na;
+use k::{connect, na};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
In the `dimforge`'s code, it seems `nalgebra` is basically re-exported as `na`.

- [rapier](https://github.com/dimforge/rapier/blob/3bac79ecacdeaa18de19127b7a6c82cbfab29d14/src/lib.rs#L24)
- [ncollide](https://github.com/dimforge/ncollide/blob/cbfb1d1ef2afa4565eb92daaac3f3be6016cd4c6/src/lib.rs#L61)
- [parry](https://github.com/dimforge/parry/blob/982d62b8dfeada2bb020527670f34a7b2bf243b8/src/lib.rs#L59)

NOTE: this is breaking change
