### PR TITLE
Enable to set unused joints for IK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde-serialize = ["nalgebra/serde-serialize", "serde"]
 log = "0.4"
 nalgebra = "0.26"
 simba = "0.4"
+structopt = "0.3"
 thiserror = "1.0"
 urdf-rs = "0.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde-serialize = ["nalgebra/serde-serialize", "serde"]
 log = "0.4"
 nalgebra = "0.26"
 simba = "0.4"
-structopt = "0.3"
 thiserror = "1.0"
 urdf-rs = "0.6"
 
@@ -28,6 +27,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 [dev-dependencies]
 doc-comment = "0.3"
 kiss3d = "0.31"
+structopt = "0.3"
 rand = "0.8"
 
 #[profile.release]

--- a/examples/interactive_ik.rs
+++ b/examples/interactive_ik.rs
@@ -23,6 +23,13 @@ use kiss3d::light::Light;
 use kiss3d::scene::SceneNode;
 use kiss3d::window::Window;
 use na::{Isometry3, Point3, Translation3, UnitQuaternion, Vector3};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(short = "i", long = "ignored-joint-names")]
+    ignored_joint_names: Vec<String>,
+}
 
 fn create_joint_with_link_array() -> k::Node<f32> {
     let fixed: k::Node<f32> = NodeBuilder::new()
@@ -136,6 +143,7 @@ fn create_cubes(window: &mut Window) -> Vec<SceneNode> {
 }
 
 fn main() {
+    let opt = Opt::from_args();
     let root = create_joint_with_link_array();
     let arm = k::SerialChain::new_unchecked(k::Chain::from_root(root));
 
@@ -201,6 +209,7 @@ fn main() {
         }
         let mut constraints = k::Constraints::default();
         constraints.rotation_x = false;
+        constraints.ignored_joint_names = opt.ignored_joint_names.clone();
         solver
             .solve_with_constraints(&arm, &target, &constraints)
             .unwrap_or_else(|err| {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -78,4 +78,6 @@ pub enum Error {
         necessary_dof
     )]
     PreconditionError { dof: usize, necessary_dof: usize },
+    #[error("There is no valid joint named {}", joint_name)]
+    InvalidJointNameError { joint_name: String },
 }

--- a/src/ik.rs
+++ b/src/ik.rs
@@ -213,7 +213,7 @@ where
         arm: &SerialChain<T>,
         target_pose: &Isometry3<T>,
         operational_space: &[bool; 6],
-        ignored_joint_indices: &Vec<usize>,
+        ignored_joint_indices: &[usize],
     ) -> Result<DVector<T>, Error> {
         let required_dof = operational_space.iter().filter(|x| **x).count();
         let orig_positions = arm.joint_positions();
@@ -249,7 +249,7 @@ where
                         + (na::DMatrix::identity(available_dof, available_dof)
                             - jacobi_inv * jacobi)
                             * subtask;
-                    for joint_index in ignored_joint_indices.iter() {
+                    for joint_index in ignored_joint_indices {
                         d_q = d_q.insert_row(*joint_index, T::zero());
                     }
                     self.add_positions_with_multiplier(&orig_positions, d_q.as_slice())
@@ -259,7 +259,7 @@ where
                         .svd(true, true)
                         .solve(&err, na::convert(EPS))
                         .unwrap();
-                    for joint_index in ignored_joint_indices.iter() {
+                    for joint_index in ignored_joint_indices {
                         d_q = d_q.insert_row(*joint_index, T::zero());
                     }
                     self.add_positions_with_multiplier(&orig_positions, d_q.as_slice())
@@ -301,7 +301,7 @@ where
             });
         }
         let mut ignored_joint_indices = Vec::new();
-        for joint_name in constraints.ignored_joint_names.iter() {
+        for joint_name in &constraints.ignored_joint_names {
             // Try to get joint index
             match arm.iter_joints().position(|x| x.name == *joint_name) {
                 Some(index) => {

--- a/tests/test_ik.rs
+++ b/tests/test_ik.rs
@@ -151,4 +151,23 @@ mod tests {
             assert!((init - end).abs() < 0.002);
         }
     }
+
+    #[test]
+    pub fn ik_fk7_with_constraints() {
+        let arm = create_joint_with_link_array7();
+        let angles = vec![0.8, 0.2, 0.0, -1.5, 0.0, -0.3, 0.0];
+        arm.set_joint_positions(&angles).unwrap();
+        let poses = arm.update_transforms();
+        let init_pose = poses.last().unwrap();
+        let solver = k::JacobianIkSolver::new(0.001, 0.001, 0.5, 100);
+        let mut constraints = k::Constraints::default();
+        constraints.rotation_x = false;
+        constraints.ignored_joint_names = vec!["wrist_roll".to_string()];
+        solver.solve_with_constraints(&arm, &init_pose, &constraints).unwrap();
+        let end_angles = arm.joint_positions();
+        for (init, end) in angles.iter().zip(end_angles.iter()) {
+            assert!((init - end).abs() < 0.001);
+            assert!(angles[6] == end_angles[6]);
+        }
+    }
 }


### PR DESCRIPTION
closes #36 

If unused joints are set, in IK calculation, 

1. the gradient on each step is projected into a feasible space
2. a linear equation is solved numerically
3. zero-gradient corresponding to unused joint is recovered to update joint angles

You can check the behavior with the following command:
```
cargo run --release --example interactive_ik -- -i shoulder_pitch
```
In this case, `shoulder_pitch` joint is fixed.