### PR TITLE
Ignore dependabot update of nalgebra, simba, and kiss3d

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,9 @@ updates:
       interval: daily
     commit-message:
       prefix: ''
+    ignore:
+      # These dependencies need to be updated at the same time.
+      - dependency-name: nalgebra
+      - dependency-name: simba
+      - dependency-name: kiss3d
     labels: []


### PR DESCRIPTION
These dependencies need to be updated at the same time.