### PR TITLE
Use parking_lot::Mutex

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,11 @@
+# https://rust-lang.github.io/rust-clippy/master/#disallowed_types
+disallowed-types = [
+    # use faster `parking_lot` instead
+    "std::sync::Mutex",
+    "std::sync::RwLock",
+    "std::sync::Condvar",
+    # TODO: use `reason =` syntax once 1.58 became stable:
+    # { path = "std::sync::Mutex", reason = "use faster `parking_lot::Mutex` instead" },
+    # { path = "std::sync::RwLock", reason = "use faster `parking_lot::RwLock` instead" },
+    # { path = "std::sync::Condvar", reason = "use faster `parking_lot::Condvar` instead" },
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets
+          # NOTE: clippy::disallowed_method/clippy::disallowed_type has been renamed to clippy::disallowed_methods/clippy::disallowed_types in Rust 1.58.
+          args: --all-targets -- -D clippy::disallowed_type
 
   docs:
     name: Docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde-serialize = ["nalgebra/serde-serialize", "serde"]
 [dependencies]
 log = "0.4"
 nalgebra = "0.29"
+parking_lot = "0.11"
 simba = "0.6"
 thiserror = "1.0"
 urdf-rs = "0.6"

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,10 +16,11 @@
 //! graph structure for kinematic chain
 use na::{Isometry3, RealField, Translation3, UnitQuaternion};
 use nalgebra as na;
+use parking_lot::{Mutex, MutexGuard};
 use simba::scalar::SubsetOf;
 use std::fmt::{self, Display};
 use std::ops::Deref;
-use std::sync::{Arc, Mutex, MutexGuard, Weak};
+use std::sync::{Arc, Weak};
 
 use super::errors::*;
 use super::iterator::*;
@@ -70,7 +71,7 @@ where
     }
 
     pub(crate) fn lock(&self) -> MutexGuard<'_, NodeImpl<T>> {
-        self.0.lock().unwrap()
+        self.0.lock()
     }
 
     pub fn joint(&self) -> JointRefGuard<'_, T> {
@@ -106,13 +107,13 @@ where
     /// Set parent and child relations at same time
     pub fn set_parent(&self, parent: &Node<T>) {
         self.lock().parent = Some(Arc::downgrade(&parent.0));
-        parent.0.lock().unwrap().children.push(self.clone());
+        parent.0.lock().children.push(self.clone());
     }
 
     /// Remove parent and child relations at same time
     pub fn remove_parent(&self, parent: &Node<T>) {
         self.lock().parent = None;
-        parent.0.lock().unwrap().children.retain(|x| *x != *self);
+        parent.0.lock().children.retain(|x| *x != *self);
     }
 
     /// # Examples
@@ -140,7 +141,7 @@ where
     /// assert!(l1.is_end());
     /// ```
     pub fn is_end(&self) -> bool {
-        self.0.lock().unwrap().children.is_empty()
+        self.0.lock().children.is_empty()
     }
 
     /// Set the origin transform of the joint
@@ -241,20 +242,12 @@ where
     /// assert_eq!(l0.joint().joint_position(), Some(-1.0));
     /// ```
     pub fn set_joint_position_clamped(&self, position: T) {
-        self.0
-            .lock()
-            .unwrap()
-            .joint
-            .set_joint_position_clamped(position);
+        self.0.lock().joint.set_joint_position_clamped(position);
     }
 
     #[inline]
     pub fn set_joint_position_unchecked(&self, position: T) {
-        self.0
-            .lock()
-            .unwrap()
-            .joint
-            .set_joint_position_unchecked(position);
+        self.0.lock().joint.set_joint_position_unchecked(position);
     }
 
     pub(crate) fn parent_world_transform(&self) -> Option<Isometry3<T>> {


### PR DESCRIPTION
Before: #69 


After:

```
bench_rctree            time:   [1.3840 us 1.3905 us 1.3982 us]                          
                        change: [-24.090% -22.771% -21.430%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  6 (6.00%) high severe

bench_rctree_get_joints time:   [205.40 ns 206.45 ns 207.83 ns]                                    
                        change: [-30.009% -29.069% -28.105%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

bench_rctree_set_joints time:   [191.14 ns 191.40 ns 191.68 ns]                                    
                        change: [-23.614% -22.624% -21.666%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe

bench_rctree_concurrent_set_joints_1000                                                                             
                        time:   [1.5055 ms 1.5074 ms 1.5093 ms]
                        change: [-46.751% -46.430% -46.145%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

bench_rctree_concurrent_get_joints_1000                                                                             
                        time:   [1.0934 ms 1.0947 ms 1.0961 ms]
                        change: [-60.615% -60.376% -60.150%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

bench_rctree_concurrent_set_get_joints_1000                                                                             
                        time:   [1.3913 ms 1.3926 ms 1.3938 ms]
                        change: [-50.261% -50.001% -49.785%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

bench_rctree_ik         time:   [6.5265 us 6.5845 us 6.6759 us]                             
                        change: [-12.322% -11.582% -10.704%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  9 (9.00%) high severe
```