### PR TITLE
Remove doc URL from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 keywords = ["kinematics", "robotics", "ik"]
 categories = ["algorithms"]
 repository = "https://github.com/openrr/k"
-documentation = "http://docs.rs/k"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field

> If no URL is specified in the manifest file, crates.io will
> automatically link your crate to the corresponding docs.rs page.