### PR TITLE
Use caches to calculate forward kinemtics effectively

### DIFF
--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -118,9 +118,7 @@ where
             }
         }
         self.position = position;
-        // TODO: have to reset descendent `world_transform_cache`
-        self.world_transform_cache.replace(None);
-        self.world_velocity_cache.replace(None);
+        self.clear_caches();
         Ok(())
     }
     /// Set the clamped position of the joint
@@ -159,9 +157,7 @@ where
     }
     pub fn set_joint_position_unchecked(&mut self, position: T) {
         self.position = position;
-        // TODO: have to reset descendent `world_transform_cache`
-        self.world_transform_cache.replace(None);
-        self.world_velocity_cache.replace(None);
+        self.clear_caches();
     }
     /// Returns the position (angle)
     #[inline]
@@ -180,7 +176,7 @@ where
     #[inline]
     pub fn set_origin(&mut self, origin: Isometry3<T>) {
         self.origin = origin;
-        self.world_transform_cache.replace(None);
+        self.clear_caches();
     }
 
     pub fn set_joint_velocity(&mut self, velocity: T) -> Result<(), Error> {
@@ -257,6 +253,13 @@ where
     #[inline]
     pub fn is_movable(&self) -> bool {
         !matches!(self.joint_type, JointType::Fixed)
+    }
+
+    /// Clear caches defined in the world coordinate
+    #[inline]
+    pub fn clear_caches(&self) {
+        self.world_transform_cache.replace(None);
+        self.world_velocity_cache.replace(None);
     }
 }
 


### PR DESCRIPTION
This PR improves the performance of forward kinematics (FK) calculation.

This PR adds a function to clear caches to `Joint` struct, and `Chain::update_transform` explicitly consider the cache status to...

- calculate FK **only one after joint positions are changed**
- calculate FK not for not all links but **for links which may be affected by joint position changes**

I verified that all tests in `openrr_planner` and `urdf-viz` work well with this change.



