### PR TITLE
Revert "Pin coverage to nightly-2022-01-14"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,8 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        # TODO: revert pinning once rustc bug fixed: https://github.com/taiki-e/cargo-llvm-cov/issues/128
-        run: rustup toolchain install nightly-2022-01-14 --component llvm-tools-preview && rustup default nightly-2022-01-14
+        run: rustup toolchain install nightly --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
       - name: Generate code coverage


### PR DESCRIPTION
This reverts commit a85ba6a8af5e5536a32d6907e90f040aac38d2b0.

https://github.com/taiki-e/cargo-llvm-cov/issues/128 has been fixed in the latest nightly.