### PR TITLE
Fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,9 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          # NOTE: clippy::disallowed_method/clippy::disallowed_type has been renamed
-          # to clippy::disallowed_methods/clippy::disallowed_types in Rust 1.59.
-          # And warned-by-default in Rust 1.60.
-          args: --all-targets -- -D clippy::disallowed_type
+          # NOTE: clippy::disallowed_methods/clippy::disallowed_types has been changed
+          # to warned-by-default in Rust 1.60.
+          args: --all-targets -- -D clippy::disallowed_types
 
   docs:
     name: Docs


### PR DESCRIPTION
clippy::disallowed_method/clippy::disallowed_type has been renamed to
clippy::disallowed_methods/clippy::disallowed_types in Rust 1.59.