### PR TITLE
Update CI for Rust 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check
 
   clippy:
     name: Clippy
@@ -70,9 +70,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          # NOTE: clippy::disallowed_methods/clippy::disallowed_types has been changed
-          # to warned-by-default in Rust 1.60.
-          args: --all-targets -- -D clippy::disallowed_types
+          args: --all-targets
 
   docs:
     name: Docs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,9 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: |
-          rustup toolchain install beta --component llvm-tools-preview
-          rustup default beta
+        run: rustup toolchain install stable --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage


### PR DESCRIPTION
- clippy::disallowed_methods/clippy::disallowed_types are now warned by default
- source-based code coverage has been stabilized
- --check is now a flag of cargo fmt subcommand

The last change was actually made in a bit earlier version (Rust 1.58?).