### PR TITLE
Replace `target_arch = "wasm32"` with `target_family = "wasm"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ urdf-rs = "0.6"
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 clap = { version = "3", features = ["derive"] }
 criterion = "0.3"
 kiss3d = "0.35"
 rand = "0.8"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [[bench]]

--- a/examples/interactive_ik.rs
+++ b/examples/interactive_ik.rs
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 fn main() {
     use nalgebra as na;
 
@@ -223,5 +223,5 @@ fn main() {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 fn main() {}

--- a/examples/interactive_ik_scara.rs
+++ b/examples/interactive_ik_scara.rs
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 fn main() {
     use nalgebra as na;
 
@@ -199,5 +199,5 @@ fn main() {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 fn main() {}

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -652,7 +652,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     #[test]

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -95,7 +95,7 @@ mod tests {
     use crate::link::*;
     use crate::node::*;
     use na::*;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     #[test]

--- a/src/ik.rs
+++ b/src/ik.rs
@@ -512,7 +512,7 @@ pub fn create_reference_positions_nullspace_function<T: RealField>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     #[test]

--- a/src/urdf.rs
+++ b/src/urdf.rs
@@ -388,10 +388,10 @@ const DEFAULT_MESH_SCALE: [f64; 3] = [1.0f64; 3];
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]
@@ -406,9 +406,9 @@ mod tests {
 
     #[test]
     fn test_tree_from_file() {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         let tree = Chain::<f32>::from_urdf_file("urdf/sample.urdf").unwrap();
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         let tree = Chain::<f32>::from(
             urdf_rs::read_from_string(include_str!("../urdf/sample.urdf")).unwrap(),
         );

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -1,7 +1,7 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/test_ik.rs
+++ b/tests/test_ik.rs
@@ -2,10 +2,10 @@ use k::connect;
 use k::prelude::*;
 use na::{Translation3, Vector3};
 use nalgebra as na;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn create_joint_with_link_array6() -> k::SerialChain<f64> {


### PR DESCRIPTION
This allows it to work on both wasm32 and wasm64.