### PR TITLE
Ignore clippy::type_complexity lint

### DIFF
--- a/src/ik.rs
+++ b/src/ik.rs
@@ -200,6 +200,7 @@ where
     ///    ),
     /// ));
     /// ```
+    #[allow(clippy::type_complexity)]
     pub fn set_nullspace_function(&mut self, func: Box<dyn Fn(&[T]) -> Vec<T> + Send + Sync>) {
         self.nullspace_function = Some(func);
     }


### PR DESCRIPTION
```
error: very complex type used. Consider factoring parts into `type` definitions
   --> src/ik.rs:203:52
    |
203 |     pub fn set_nullspace_function(&mut self, func: Box<dyn Fn(&[T]) -> Vec<T> + Send + Sync>) {
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::type-complexity` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
```