### PR TITLE
Remove manual installation of llvm-tools-preview

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage


### PR DESCRIPTION
Since cargo-llvm-cov [0.5.0](https://github.com/taiki-e/cargo-llvm-cov/releases/tag/v0.5.0), you can omit this.