### PR TITLE
Use VecDeque for Descendants instead of Vec

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -17,6 +17,7 @@
 use super::node::*;
 use nalgebra::RealField;
 use simba::scalar::SubsetOf;
+use std::collections::VecDeque;
 
 #[derive(Debug)]
 /// Iterator for parents
@@ -58,7 +59,7 @@ pub struct Descendants<T>
 where
     T: RealField,
 {
-    stack: Vec<Node<T>>,
+    stack: VecDeque<Node<T>>,
 }
 
 impl<T> Descendants<T>
@@ -66,7 +67,9 @@ where
     T: RealField,
 {
     pub fn new(stack: Vec<Node<T>>) -> Self {
-        Self { stack }
+        Self {
+            stack: stack.into(),
+        }
     }
 }
 
@@ -77,7 +80,7 @@ where
     type Item = Node<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let node = match self.stack.pop() {
+        let node = match self.stack.pop_front() {
             Some(node) => node,
             None => {
                 return None;

--- a/src/urdf.rs
+++ b/src/urdf.rs
@@ -420,6 +420,6 @@ mod tests {
         assert_eq!(names.len(), 13);
         println!("{}", names[0]);
         assert_eq!(names[0], "root");
-        assert_eq!(names[1], "r_shoulder_yaw");
+        assert_eq!(names[1], "l_shoulder_yaw");
     }
 }

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -17,7 +17,7 @@ fn test_tree() {
     assert!(all_names.len() == 13);
     println!("{}", all_names[0]);
     assert!(all_names[0] == "root");
-    assert!(all_names[1] == "r_shoulder_yaw");
+    assert!(all_names[1] == "l_shoulder_yaw");
 
     let names = tree
         .iter_joints()
@@ -25,7 +25,7 @@ fn test_tree() {
         .collect::<Vec<_>>();
     assert!(names.len() == 12);
     println!("{}", names[0]);
-    assert!(names[0] == "r_shoulder_yaw");
+    assert!(names[0] == "l_shoulder_yaw");
 }
 
 #[test]


### PR DESCRIPTION
to make iteration orders compatible with URDF
