### PR TITLE
Fix and refactor iterator.rs

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -59,16 +59,16 @@ pub struct Descendants<T>
 where
     T: RealField,
 {
-    stack: VecDeque<Node<T>>,
+    queue: VecDeque<Node<T>>,
 }
 
 impl<T> Descendants<T>
 where
     T: RealField,
 {
-    pub fn new(stack: Vec<Node<T>>) -> Self {
+    pub fn new(queue: Vec<Node<T>>) -> Self {
         Self {
-            stack: stack.into(),
+            queue: queue.into(),
         }
     }
 }
@@ -80,7 +80,7 @@ where
     type Item = Node<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let node = match self.stack.pop_front() {
+        let node = match self.queue.pop_front() {
             Some(node) => node,
             None => {
                 return None;
@@ -88,9 +88,9 @@ where
         };
 
         // procedure for prepending (no prepending function exists)
-        let mut new_stack: VecDeque<Node<T>> = node.children().clone().into();
-        new_stack.append(&mut (self.stack.clone()));
-        self.stack = new_stack;
+        let mut new_queue: VecDeque<Node<T>> = node.children().clone().into();
+        new_queue.append(&mut (self.queue.clone()));
+        self.queue = new_queue;
 
         Some(node)
     }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -86,7 +86,12 @@ where
                 return None;
             }
         };
-        self.stack.extend(node.children().clone());
+
+        // procedure for prepending (no prepending function exists)
+        let mut new_stack: VecDeque<Node<T>> = node.children().clone().into();
+        new_stack.append(&mut (self.stack.clone()));
+        self.stack = new_stack;
+
         Some(node)
     }
 }

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -14,18 +14,32 @@ fn test_tree() {
         .iter()
         .map(|link| link.joint().name.clone())
         .collect::<Vec<_>>();
-    assert!(all_names.len() == 13);
-    println!("{}", all_names[0]);
-    assert!(all_names[0] == "root");
-    assert!(all_names[1] == "l_shoulder_yaw");
+    assert_eq!(all_names.len(), 13);
+    assert_eq!(
+        all_names,
+        [
+            "root",
+            "l_shoulder_yaw",
+            "l_shoulder_pitch",
+            "l_shoulder_roll",
+            "l_elbow_pitch",
+            "l_wrist_yaw",
+            "l_wrist_pitch",
+            "r_shoulder_yaw",
+            "r_shoulder_pitch",
+            "r_shoulder_roll",
+            "r_elbow_pitch",
+            "r_wrist_yaw",
+            "r_wrist_pitch"
+        ]
+    );
 
     let names = tree
         .iter_joints()
         .map(|j| j.name.clone())
         .collect::<Vec<_>>();
-    assert!(names.len() == 12);
-    println!("{}", names[0]);
-    assert!(names[0] == "l_shoulder_yaw");
+    assert_eq!(names.len(), 12);
+    assert_eq!(names[0], "l_shoulder_yaw");
 }
 
 #[test]


### PR DESCRIPTION
1. We found that #102 lacks the change of algorithm merging queues, so this PR fixes it.
2. the variable name `stack` is misleading. It is renamed because it is no longer a stack but a queue.
3. This PR refactors tests, mainly along with the changes in 1.
