### PR TITLE
fix link transform calculation

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -834,19 +834,20 @@ mod tests {
             .name("j1")
             .joint_type(JointType::Fixed)
             .into_node();
-	joint1.set_parent(&joint0);
-	let link1 = LinkBuilder::new()
-	    .name("l1")
-	    .finalize();
-	joint1.set_link(Some(link1));
+        joint1.set_parent(&joint0);
+        let link1 = LinkBuilder::new().name("l1").finalize();
+        joint1.set_link(Some(link1));
 
-	let chain = Chain::from_root(joint0);
+        let chain = Chain::from_root(joint0);
 
-	chain.update_link_transforms();
+        chain.update_link_transforms();
 
-	for link in chain.iter_links() {
-	    println!("{:?}", link.inertial.world_transform());
-	    assert!((link.inertial.world_transform().unwrap().translation.x - 1.0f64).abs() < f64::EPSILON);
-	}
+        for link in chain.iter_links() {
+            println!("{:?}", link.inertial.world_transform());
+            assert!(
+                (link.inertial.world_transform().unwrap().translation.x - 1.0f64).abs()
+                    < f64::EPSILON
+            );
+        }
     }
 }


### PR DESCRIPTION
Links are conceptually attached to their joints.
The old code treats them as if they were attached to the joints of the parent node, which is the joints parent.
This PR changes this so links use the joint of their node as their parent joint, which is in line with how urdfs are loaded.